### PR TITLE
New fetcher

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -9,7 +9,7 @@ export default abstract class extends Command {
     super(argv, config)
 
     const client = new APIClient(this.config, {})
-    const host = process.env.HEROKU_ADDONS_HOST
+    const host = process.env.HEROKU_DATA_HOST
     client.defaults.host = host ? url.parse(host).host : 'postgres-api.heroku.com'
     client.defaults.headers = {
       ...this.heroku.defaults.headers,

--- a/src/base.ts
+++ b/src/base.ts
@@ -9,8 +9,7 @@ export default abstract class extends Command {
     super(argv, config)
 
     const client = new APIClient(this.config, {})
-    const host = process.env.HEROKU_DATA_HOST
-    client.defaults.host = host || 'postgres-api.heroku.com'
+    client.defaults.host = process.env.HEROKU_DATA_HOST || 'postgres-api.heroku.com'
     client.defaults.headers = {
       ...this.heroku.defaults.headers,
       authorization: `Basic ${Buffer.from(':' + this.heroku.auth).toString('base64')}`

--- a/src/base.ts
+++ b/src/base.ts
@@ -10,7 +10,7 @@ export default abstract class extends Command {
 
     const client = new APIClient(this.config, {})
     const host = process.env.HEROKU_DATA_HOST
-    client.defaults.host = host ? url.parse(host).host : 'postgres-api.heroku.com'
+    client.defaults.host = host ? host : 'postgres-api.heroku.com'
     client.defaults.headers = {
       ...this.heroku.defaults.headers,
       authorization: `Basic ${Buffer.from(':' + this.heroku.auth).toString('base64')}`

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,6 +1,5 @@
 import {APIClient, Command} from '@heroku-cli/command'
 import {IConfig} from '@oclif/config'
-import * as url from 'url'
 
 export default abstract class extends Command {
   shogun: APIClient

--- a/src/base.ts
+++ b/src/base.ts
@@ -10,7 +10,7 @@ export default abstract class extends Command {
 
     const client = new APIClient(this.config, {})
     const host = process.env.HEROKU_DATA_HOST
-    client.defaults.host = host ? host : 'postgres-api.heroku.com'
+    client.defaults.host = host || 'postgres-api.heroku.com'
     client.defaults.headers = {
       ...this.heroku.defaults.headers,
       authorization: `Basic ${Buffer.from(':' + this.heroku.auth).toString('base64')}`

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,15 +1,21 @@
-import {Command} from '@heroku-cli/command'
+import {APIClient, Command} from '@heroku-cli/command'
 import {IConfig} from '@oclif/config'
+import * as url from 'url'
 
 export default abstract class extends Command {
+  shogun: APIClient
+
   protected constructor(argv: string[], config: IConfig) {
     super(argv, config)
 
-    this.heroku.defaults.host = process.env.HEROKU_DATA_HOST || 'postgres-api.heroku.com'
-    this.heroku.defaults.headers = {
+    const client = new APIClient(this.config, {})
+    const host = process.env.HEROKU_ADDONS_HOST
+    client.defaults.host = host ? url.parse(host).host : 'postgres-api.heroku.com'
+    client.defaults.headers = {
       ...this.heroku.defaults.headers,
       authorization: `Basic ${Buffer.from(':' + this.heroku.auth).toString('base64')}`
     }
+    this.shogun = client
   }
 }
 

--- a/src/commands/pg/privatelink/access/add.ts
+++ b/src/commands/pg/privatelink/access/add.ts
@@ -31,7 +31,7 @@ export default class EndpointsAccessAdd extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessAdd)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = await fetcher(this.heroku, args.database, flags.app)
     const account_ids = flags['aws-account-id']
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
 

--- a/src/commands/pg/privatelink/access/add.ts
+++ b/src/commands/pg/privatelink/access/add.ts
@@ -31,13 +31,13 @@ export default class EndpointsAccessAdd extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessAdd)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = args.database || await fetcher(this.shogun, flags.app)
     const account_ids = flags['aws-account-id']
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
 
     cli.action.start(`Adding ${accountFormatted} to the whitelist`)
-    await this.heroku.put(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
-      ...this.heroku.defaults,
+    await this.shogun.put(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
+      ...this.shogun.defaults,
       body: {
         whitelisted_accounts: account_ids
       }

--- a/src/commands/pg/privatelink/access/add.ts
+++ b/src/commands/pg/privatelink/access/add.ts
@@ -31,7 +31,7 @@ export default class EndpointsAccessAdd extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessAdd)
-    const database = args.database || await fetcher(this.shogun, flags.app)
+    const database = args.database || await fetcher(this.heroku, flags.app)
     const account_ids = flags['aws-account-id']
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
 

--- a/src/commands/pg/privatelink/access/index.ts
+++ b/src/commands/pg/privatelink/access/index.ts
@@ -21,7 +21,7 @@ export default class EndpointsAccessIndex extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessIndex)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = await fetcher(this.heroku, args.database, flags.app)
 
     const {body: {whitelisted_accounts}} = await this.shogun.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)
 

--- a/src/commands/pg/privatelink/access/index.ts
+++ b/src/commands/pg/privatelink/access/index.ts
@@ -21,9 +21,9 @@ export default class EndpointsAccessIndex extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessIndex)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = args.database || await fetcher(this.shogun, flags.app)
 
-    const {body: {whitelisted_accounts}} = await this.heroku.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.heroku.defaults)
+    const {body: {whitelisted_accounts}} = await this.shogun.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)
 
     if (whitelisted_accounts.length > 0) {
       cli.table(whitelisted_accounts, {

--- a/src/commands/pg/privatelink/access/index.ts
+++ b/src/commands/pg/privatelink/access/index.ts
@@ -21,7 +21,7 @@ export default class EndpointsAccessIndex extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessIndex)
-    const database = args.database || await fetcher(this.shogun, flags.app)
+    const database = args.database || await fetcher(this.heroku, flags.app)
 
     const {body: {whitelisted_accounts}} = await this.shogun.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)
 

--- a/src/commands/pg/privatelink/access/remove.ts
+++ b/src/commands/pg/privatelink/access/remove.ts
@@ -31,7 +31,7 @@ export default class EndpointsAccessRemove extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessRemove)
-    const database = args.database || await fetcher(this.shogun, flags.app)
+    const database = args.database || await fetcher(this.heroku, flags.app)
     const account_ids = flags['aws-account-id']
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
 

--- a/src/commands/pg/privatelink/access/remove.ts
+++ b/src/commands/pg/privatelink/access/remove.ts
@@ -31,7 +31,7 @@ export default class EndpointsAccessRemove extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessRemove)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = await fetcher(this.heroku, args.database, flags.app)
     const account_ids = flags['aws-account-id']
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
 

--- a/src/commands/pg/privatelink/access/remove.ts
+++ b/src/commands/pg/privatelink/access/remove.ts
@@ -31,13 +31,13 @@ export default class EndpointsAccessRemove extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsAccessRemove)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = args.database || await fetcher(this.shogun, flags.app)
     const account_ids = flags['aws-account-id']
     const accountFormatted = account_ids.length > 1 ? 'accounts' : 'account'
 
     cli.action.start(`Removing ${accountFormatted} from the whitelist`)
-    await this.heroku.patch(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
-      ...this.heroku.defaults,
+    await this.shogun.patch(`/private-link/v0/databases/${database}/whitelisted_accounts`, {
+      ...this.shogun.defaults,
       body: {
         whitelisted_accounts: account_ids
       }

--- a/src/commands/pg/privatelink/create.ts
+++ b/src/commands/pg/privatelink/create.ts
@@ -32,7 +32,7 @@ export default class EndpointsCreate extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsCreate)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = await fetcher(this.heroku, args.database, flags.app)
     const account_ids = flags['aws-account-id']
 
     cli.action.start('Creating privatelink endpoint')

--- a/src/commands/pg/privatelink/create.ts
+++ b/src/commands/pg/privatelink/create.ts
@@ -32,12 +32,12 @@ export default class EndpointsCreate extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsCreate)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = args.database || await fetcher(this.shogun, flags.app)
     const account_ids = flags['aws-account-id']
 
     cli.action.start('Creating privatelink endpoint')
-    const {body: res} = await this.heroku.post<PrivateLinkDB>(`/private-link/v0/databases/${database}`, {
-      ...this.heroku.defaults,
+    const {body: res} = await this.shogun.post<PrivateLinkDB>(`/private-link/v0/databases/${database}`, {
+      ...this.shogun.defaults,
       body: {
         whitelisted_accounts: account_ids
       }

--- a/src/commands/pg/privatelink/create.ts
+++ b/src/commands/pg/privatelink/create.ts
@@ -32,7 +32,7 @@ export default class EndpointsCreate extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsCreate)
-    const database = args.database || await fetcher(this.shogun, flags.app)
+    const database = args.database || await fetcher(this.heroku, flags.app)
     const account_ids = flags['aws-account-id']
 
     cli.action.start('Creating privatelink endpoint')

--- a/src/commands/pg/privatelink/destroy.ts
+++ b/src/commands/pg/privatelink/destroy.ts
@@ -21,7 +21,7 @@ export default class EndpointsDestroy extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsDestroy)
-    const database = args.database || await fetcher(this.shogun, flags.app)
+    const database = args.database || await fetcher(this.heroku, flags.app)
 
     cli.action.start('Destroying privatelink endpoint')
     await this.shogun.delete<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)

--- a/src/commands/pg/privatelink/destroy.ts
+++ b/src/commands/pg/privatelink/destroy.ts
@@ -21,10 +21,10 @@ export default class EndpointsDestroy extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsDestroy)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = args.database || await fetcher(this.shogun, flags.app)
 
     cli.action.start('Destroying privatelink endpoint')
-    await this.heroku.delete<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.heroku.defaults)
+    await this.shogun.delete<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)
     cli.action.stop()
   }
 }

--- a/src/commands/pg/privatelink/destroy.ts
+++ b/src/commands/pg/privatelink/destroy.ts
@@ -21,7 +21,7 @@ export default class EndpointsDestroy extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsDestroy)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = await fetcher(this.heroku, args.database, flags.app)
 
     cli.action.start('Destroying privatelink endpoint')
     await this.shogun.delete<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)

--- a/src/commands/pg/privatelink/index.ts
+++ b/src/commands/pg/privatelink/index.ts
@@ -6,7 +6,7 @@ import BaseCommand, {PrivateLinkDB} from '../../../base'
 import fetcher from '../../../lib/fetcher'
 
 export default class EndpointsIndex extends BaseCommand {
-  static description = 'list all your privatelink endpoints'
+  static description = 'list all your privatelink endpoints!'
 
   static args = [
     {name: 'database'}
@@ -23,8 +23,8 @@ export default class EndpointsIndex extends BaseCommand {
   async run() {
     const {args, flags} = this.parse(EndpointsIndex)
 
-    const database = args.database || await fetcher(this.heroku, flags.app)
-    const {body: res} = await this.heroku.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.heroku.defaults)
+    const database = args.database || await fetcher(this.shogun, flags.app)
+    const {body: res} = await this.shogun.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)
 
     if (res.status === 'Provisioning') {
       this.log()

--- a/src/commands/pg/privatelink/index.ts
+++ b/src/commands/pg/privatelink/index.ts
@@ -23,7 +23,7 @@ export default class EndpointsIndex extends BaseCommand {
   async run() {
     const {args, flags} = this.parse(EndpointsIndex)
 
-    const database = args.database || await fetcher(this.shogun, flags.app)
+    const database = args.database || await fetcher(this.heroku, flags.app)
     const {body: res} = await this.shogun.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)
 
     if (res.status === 'Provisioning') {

--- a/src/commands/pg/privatelink/index.ts
+++ b/src/commands/pg/privatelink/index.ts
@@ -22,8 +22,7 @@ export default class EndpointsIndex extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsIndex)
-
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = await fetcher(this.heroku, args.database, flags.app)
     const {body: res} = await this.shogun.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)
 
     if (res.status === 'Provisioning') {

--- a/src/commands/pg/privatelink/wait.ts
+++ b/src/commands/pg/privatelink/wait.ts
@@ -21,12 +21,12 @@ export default class EndpointsWait extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsWait)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = args.database || await fetcher(this.shogun, flags.app)
 
     let status
     cli.action.start('Waiting for the privatelink endpoint to be provisioned')
     while (status !== 'Operational') {
-      let {body: res} = await this.heroku.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.heroku.defaults)
+      let {body: res} = await this.shogun.get<PrivateLinkDB>(`/private-link/v0/databases/${database}`, this.shogun.defaults)
       status = res.status
       await cli.wait(3000)
     }

--- a/src/commands/pg/privatelink/wait.ts
+++ b/src/commands/pg/privatelink/wait.ts
@@ -21,7 +21,7 @@ export default class EndpointsWait extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsWait)
-    const database = args.database || await fetcher(this.shogun, flags.app)
+    const database = args.database || await fetcher(this.heroku, flags.app)
 
     let status
     cli.action.start('Waiting for the privatelink endpoint to be provisioned')

--- a/src/commands/pg/privatelink/wait.ts
+++ b/src/commands/pg/privatelink/wait.ts
@@ -21,7 +21,7 @@ export default class EndpointsWait extends BaseCommand {
 
   async run() {
     const {args, flags} = this.parse(EndpointsWait)
-    const database = args.database || await fetcher(this.heroku, flags.app)
+    const database = await fetcher(this.heroku, args.database, flags.app)
 
     let status
     cli.action.start('Waiting for the privatelink endpoint to be provisioned')

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -11,7 +11,7 @@ export default async function (heroku: any, addon_attachment: string, app: strin
   )
 
   if (res.id !== 'not_found') {
-    return res[0]['addon'].name
+    return res[0].addon.name
   } else {
     cli.error(res.message)
   }

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -1,13 +1,18 @@
 import {cli} from 'cli-ux'
 
-export default async function (heroku: any, app: string) {
-  const {body: addons} = await heroku.get(`https://api.heroku.com/apps/${app}/addons`)
-  const postgres_addons = addons.filter((addon: any) => addon.addon_service.name.includes('heroku-postgresql'))
-  if (postgres_addons.length === 1) {
-    return postgres_addons[0].name
-  } else if (postgres_addons.length > 1) {
-    cli.error(`found more than one Heroku Postgres add-on on ${app}: ${postgres_addons.map((addon: any) => addon.name).join(', ')}`, {exit: 1})
+export default async function (heroku: any, addon_attachment: string, app: string) {
+  const db = addon_attachment || 'DATABASE_URL'
+  const {body: res} = await heroku.post('/actions/addon-attachments/resolve', {
+    body: {
+      app,
+      addon_attachment: db,
+      addon_service: 'heroku-postgresql'
+    }}
+  )
+
+  if (res.id !== 'not_found') {
+    return res[0]['addon'].name
   } else {
-    cli.error(`found no Heroku Postgres add-ons on ${app}`, {exit: 1})
+    cli.error(res.message)
   }
 }

--- a/test/commands/pg/privatelink/access/add.test.ts
+++ b/test/commands/pg/privatelink/access/add.test.ts
@@ -1,3 +1,4 @@
+import {addonsFetcherResponse} from '../../../../fixtures'
 import {expect, test} from '../../../../test'
 
 describe('pg:privatelink:access:add', () => {
@@ -5,6 +6,10 @@ describe('pg:privatelink:access:add', () => {
     .nock('https://postgres-api.heroku.com', api => api
       .put('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:root']})
       .reply(200, {})
+    )
+    .nock('https://api.heroku.com', api => api
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, addonsFetcherResponse)
     )
     .stdout()
     .stderr()
@@ -17,6 +22,10 @@ describe('pg:privatelink:access:add', () => {
     .nock('https://postgres-api.heroku.com', api => api
       .put('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:resource1', '123456789012:resource2']})
       .reply(200, {})
+    )
+    .nock('https://api.heroku.com', api => api
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, addonsFetcherResponse)
     )
     .stdout()
     .stderr()

--- a/test/commands/pg/privatelink/access/index.test.ts
+++ b/test/commands/pg/privatelink/access/index.test.ts
@@ -1,3 +1,4 @@
+import {addonsFetcherResponse} from '../../../../fixtures'
 import {expect, test} from '../../../../test'
 
 describe('pg:privatelink:access', () => {
@@ -14,6 +15,10 @@ describe('pg:privatelink:access', () => {
     .nock('https://postgres-api.heroku.com', api => api
       .get('/private-link/v0/databases/postgres-123')
       .reply(200, privateLinkWhitelistResponse)
+    )
+    .nock('https://api.heroku.com', api => api
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, addonsFetcherResponse)
     )
     .stdout()
     .stderr()

--- a/test/commands/pg/privatelink/access/remove.test.ts
+++ b/test/commands/pg/privatelink/access/remove.test.ts
@@ -1,3 +1,4 @@
+import {addonsFetcherResponse} from '../../../../fixtures'
 import {expect, test} from '../../../../test'
 
 describe('pg:privatelink:access:remove', () => {
@@ -5,6 +6,10 @@ describe('pg:privatelink:access:remove', () => {
     .nock('https://postgres-api.heroku.com', api => api
       .patch('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:root']})
       .reply(200, {})
+    )
+    .nock('https://api.heroku.com', api => api
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, addonsFetcherResponse)
     )
     .stdout()
     .stderr()
@@ -17,6 +22,10 @@ describe('pg:privatelink:access:remove', () => {
     .nock('https://postgres-api.heroku.com', api => api
       .patch('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:resource1', '123456789012:resource2']})
       .reply(200, {})
+    )
+    .nock('https://api.heroku.com', api => api
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, addonsFetcherResponse)
     )
     .stdout()
     .stderr()

--- a/test/commands/pg/privatelink/create.test.ts
+++ b/test/commands/pg/privatelink/create.test.ts
@@ -1,3 +1,4 @@
+import {addonsFetcherResponse} from '../../../fixtures'
 import {expect, test} from '../../../test'
 
 describe('pg:privatelink:create', () => {
@@ -5,6 +6,10 @@ describe('pg:privatelink:create', () => {
     .nock('https://postgres-api.heroku.com', api => api
       .post('/private-link/v0/databases/postgres-123', {whitelisted_accounts: ['123456789012:root']})
       .reply(200, {})
+    )
+    .nock('https://api.heroku.com', api => api
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, addonsFetcherResponse)
     )
     .stderr()
     .stdout()
@@ -17,6 +22,10 @@ describe('pg:privatelink:create', () => {
     .nock('https://postgres-api.heroku.com', api => api
       .post('/private-link/v0/databases/postgres-123', {whitelisted_accounts: ['123456789012:resource1', '123456789012:resource2']})
       .reply(200, {})
+    )
+    .nock('https://api.heroku.com', api => api
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, addonsFetcherResponse)
     )
     .stderr()
     .stdout()

--- a/test/commands/pg/privatelink/destroy.test.ts
+++ b/test/commands/pg/privatelink/destroy.test.ts
@@ -1,3 +1,4 @@
+import {addonsFetcherResponse} from '../../../fixtures'
 import {expect, test} from '../../../test'
 
 describe('pg:privatelink:destroy', () => {
@@ -5,6 +6,10 @@ describe('pg:privatelink:destroy', () => {
     .nock('https://postgres-api.heroku.com', api => api
       .delete('/private-link/v0/databases/postgres-123')
       .reply(200, {})
+    )
+    .nock('https://api.heroku.com', api => api
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, addonsFetcherResponse)
     )
     .stderr()
     .stdout()

--- a/test/commands/pg/privatelink/index.test.ts
+++ b/test/commands/pg/privatelink/index.test.ts
@@ -1,34 +1,17 @@
+import {addonsFetcherResponse,
+  privateLinkNewlyCreated,
+  privateLinkWithConnections} from '../../../fixtures'
 import {expect, test} from '../../../test'
 
 describe('privatelink', () => {
-  const privateLinkNewlyCreated = {
-    app: {name: 'myapp'},
-    addon: {name: 'postgres-123'},
-    status: 'Provisioning',
-    service_name: 'com.amazonaws.vpce.testvpc"',
-    connections: [],
-    whitelisted_accounts: []
-  }
-
-  const privateLinkOperational = {
-    ...privateLinkNewlyCreated,
-    status: 'Operational',
-  }
-
-  const privateLinkWithConnections = {
-    ...privateLinkOperational,
-    connections: [
-      {endpoint_id: '123456', owner_arn: 'arn:aws:iam::12345567890:root', status: 'Available'}
-    ],
-    whitelisted_accounts: [
-      {arn: 'arn:aws:iam::12345567890:root', status: 'Active'}
-    ]
-  }
-
   test
     .nock('https://postgres-api.heroku.com', api => api
       .get('/private-link/v0/databases/postgres-123')
       .reply(200, privateLinkWithConnections)
+    )
+    .nock('https://api.heroku.com', api => api
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, addonsFetcherResponse)
     )
     .stdout()
     .stderr()
@@ -51,6 +34,10 @@ describe('privatelink', () => {
     .nock('https://postgres-api.heroku.com', api => api
       .get('/private-link/v0/databases/postgres-123')
       .reply(200, privateLinkNewlyCreated)
+    )
+    .nock('https://api.heroku.com', api => api
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, addonsFetcherResponse)
     )
     .stdout()
     .stderr()

--- a/test/commands/pg/privatelink/wait.test.ts
+++ b/test/commands/pg/privatelink/wait.test.ts
@@ -1,3 +1,4 @@
+import {addonsFetcherResponse} from '../../../fixtures'
 import {expect, test} from '../../../test'
 
 describe('pg:privatelink:wait', () => {
@@ -14,6 +15,10 @@ describe('pg:privatelink:wait', () => {
     .nock('https://postgres-api.heroku.com', api => api
       .get('/private-link/v0/databases/postgres-123')
       .reply(200, privateLinkListResponse)
+    )
+    .nock('https://api.heroku.com', api => api
+      .post('/actions/addon-attachments/resolve')
+      .reply(200, addonsFetcherResponse)
     )
     .stdout()
     .stderr()

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -1,0 +1,47 @@
+export const addonsFetcherResponse = [
+  {
+    addon: {
+      id: '68ac478b-257c-4b0c-a2bf-b29b115486cd',
+      name: 'postgres-123',
+      app: {
+        id: '097c056a-8d45-4f18-9501-05e8708652c0',
+        name: 'myapp'
+      }
+    },
+    app: {
+      id: '097c056a-8d45-4f18-9501-05e8708652c0',
+      name: 'myapp'
+    },
+    id: '2e2805c2-1aa7-4fed-9e4d-a54d24d50992',
+    name: 'HEROKU_POSTGRESQL_PINK',
+    namespace: null,
+    created_at: '2019-02-08T18:31:31Z',
+    updated_at: '2019-02-08T18:31:31Z',
+    web_url: 'https://addons-sso.heroku.com/apps/fe3c96b2-f839-4efa-a708-06c26c7407cc/addons/68ac478b-257c-4b0c-a2bf-b29b115486cd',
+    log_input_url: null
+  }
+]
+
+export const privateLinkNewlyCreated = {
+  app: {name: 'myapp'},
+  addon: {name: 'postgres-123'},
+  status: 'Provisioning',
+  service_name: 'com.amazonaws.vpce.testvpc',
+  connections: [],
+  whitelisted_accounts: []
+}
+
+export const privateLinkOperational = {
+  ...privateLinkNewlyCreated,
+  status: 'Operational',
+}
+
+export const privateLinkWithConnections = {
+  ...privateLinkOperational,
+  connections: [
+    {endpoint_id: '123456', owner_arn: 'arn:aws:iam::12345567890:root', status: 'Available'}
+  ],
+  whitelisted_accounts: [
+    {arn: 'arn:aws:iam::12345567890:root', status: 'Active'}
+  ]
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@oclif/tslint",
-  "rules": {
-    "no-string-literal": false
-  }
+  "extends": "@oclif/tslint"
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@oclif/tslint"
+  "extends": "@oclif/tslint",
+  "rules": {
+    "no-string-literal": false
+  }
 }


### PR DESCRIPTION
### What does this do?
* Updates the API client to use its own this.shogun, instead of this.heroku.
* Updates the fetcher to support addon attachment names/URLs e.g. `DATABASE_URL`, `HEROKU_POSTGRESQL_PINK`, `HEROKU_POSTGRESQL_PINK_URL`

See this [Trello card for more details](https://trello.com/c/2Hg1NKyv/90-endpoints-cli-database-finder-bug)