### PR TITLE
Rename project to heroku-data-privatelink-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm install -g @heroku-cli/plugin-data-privatelink
 $ heroku COMMAND
 running command...
 $ heroku (-v|--version|version)
-@heroku-cli/plugin-data-privatelink/1.0.0 darwin-x64 node-v10.15.1
+@heroku-cli/plugin-data-privatelink/0.8.0 darwin-x64 node-v10.15.1
 $ heroku --help [COMMAND]
 USAGE
   $ heroku COMMAND
@@ -49,7 +49,7 @@ EXAMPLE
   $ heroku data:privatelink postgresql-sushi-12345
 ```
 
-_See code: [src/commands/data/privatelink/index.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/index.ts)_
+_See code: [src/commands/data/privatelink/index.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v0.8.0/src/commands/data/privatelink/index.ts)_
 
 ## `heroku data:privatelink:access [ADDON]`
 
@@ -66,7 +66,7 @@ EXAMPLE
   $ heroku data:privatelink:access postgresql-sushi-12345
 ```
 
-_See code: [src/commands/data/privatelink/access/index.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/access/index.ts)_
+_See code: [src/commands/data/privatelink/access/index.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v0.8.0/src/commands/data/privatelink/access/index.ts)_
 
 ## `heroku data:privatelink:access:add [ADDON]`
 
@@ -86,7 +86,7 @@ EXAMPLES
   123456789012:user/xyz
 ```
 
-_See code: [src/commands/data/privatelink/access/add.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/access/add.ts)_
+_See code: [src/commands/data/privatelink/access/add.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v0.8.0/src/commands/data/privatelink/access/add.ts)_
 
 ## `heroku data:privatelink:access:remove [ADDON]`
 
@@ -106,7 +106,7 @@ EXAMPLES
   123456789012:user/xyz
 ```
 
-_See code: [src/commands/data/privatelink/access/remove.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/access/remove.ts)_
+_See code: [src/commands/data/privatelink/access/remove.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v0.8.0/src/commands/data/privatelink/access/remove.ts)_
 
 ## `heroku data:privatelink:create [ADDON]`
 
@@ -126,7 +126,7 @@ EXAMPLES
   123456789012:user/xyz
 ```
 
-_See code: [src/commands/data/privatelink/create.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/create.ts)_
+_See code: [src/commands/data/privatelink/create.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v0.8.0/src/commands/data/privatelink/create.ts)_
 
 ## `heroku data:privatelink:destroy [ADDON]`
 
@@ -143,7 +143,7 @@ EXAMPLE
   $ heroku data:privatelink:destroy postgresql-sushi-12345
 ```
 
-_See code: [src/commands/data/privatelink/destroy.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/destroy.ts)_
+_See code: [src/commands/data/privatelink/destroy.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v0.8.0/src/commands/data/privatelink/destroy.ts)_
 
 ## `heroku data:privatelink:wait [ADDON]`
 
@@ -160,5 +160,5 @@ EXAMPLE
   $ heroku data:privatelink:wait postgresql-sushi-12345
 ```
 
-_See code: [src/commands/data/privatelink/wait.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/wait.ts)_
+_See code: [src/commands/data/privatelink/wait.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v0.8.0/src/commands/data/privatelink/wait.ts)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Heroku Postgres via PrivateLink CLI
 # Usage
 <!-- usage -->
 ```sh-session
-$ npm install -g @heroku-cli/plugin-pg-privatelink
+$ npm install -g @heroku-cli/plugin-data-privatelink
 $ heroku COMMAND
 running command...
 $ heroku (-v|--version|version)
-@heroku-cli/plugin-pg-privatelink/0.8.0 darwin-x64 node-v10.15.1
+@heroku-cli/plugin-data-privatelink/1.0.0 darwin-x64 node-v10.15.1
 $ heroku --help [COMMAND]
 USAGE
   $ heroku COMMAND
@@ -26,139 +26,139 @@ USAGE
 <!-- usagestop -->
 # Commands
 <!-- commands -->
-* [`heroku pg:privatelink [DATABASE]`](#heroku-pgprivatelink-database)
-* [`heroku pg:privatelink:access [DATABASE]`](#heroku-pgprivatelinkaccess-database)
-* [`heroku pg:privatelink:access:add [DATABASE]`](#heroku-pgprivatelinkaccessadd-database)
-* [`heroku pg:privatelink:access:remove [DATABASE]`](#heroku-pgprivatelinkaccessremove-database)
-* [`heroku pg:privatelink:create [DATABASE]`](#heroku-pgprivatelinkcreate-database)
-* [`heroku pg:privatelink:destroy [DATABASE]`](#heroku-pgprivatelinkdestroy-database)
-* [`heroku pg:privatelink:wait [DATABASE]`](#heroku-pgprivatelinkwait-database)
+* [`heroku data:privatelink [ADDON]`](#heroku-dataprivatelink-addon)
+* [`heroku data:privatelink:access [ADDON]`](#heroku-dataprivatelinkaccess-addon)
+* [`heroku data:privatelink:access:add [ADDON]`](#heroku-dataprivatelinkaccessadd-addon)
+* [`heroku data:privatelink:access:remove [ADDON]`](#heroku-dataprivatelinkaccessremove-addon)
+* [`heroku data:privatelink:create [ADDON]`](#heroku-dataprivatelinkcreate-addon)
+* [`heroku data:privatelink:destroy [ADDON]`](#heroku-dataprivatelinkdestroy-addon)
+* [`heroku data:privatelink:wait [ADDON]`](#heroku-dataprivatelinkwait-addon)
 
-## `heroku pg:privatelink [DATABASE]`
+## `heroku data:privatelink [ADDON]`
 
 list all your privatelink endpoints!
 
 ```
 USAGE
-  $ heroku pg:privatelink [DATABASE]
+  $ heroku data:privatelink [ADDON]
 
 OPTIONS
   -a, --app=app  (required) app to run command against
 
 EXAMPLE
-  $ heroku pg:privatelink postgresql-sushi-12345
+  $ heroku data:privatelink postgresql-sushi-12345
 ```
 
-_See code: [src/commands/pg/privatelink/index.ts](https://github.com/heroku/heroku-pg-privatelink-cli/blob/v0.8.0/src/commands/pg/privatelink/index.ts)_
+_See code: [src/commands/data/privatelink/index.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/index.ts)_
 
-## `heroku pg:privatelink:access [DATABASE]`
+## `heroku data:privatelink:access [ADDON]`
 
 list all accounts for your privatelink endpoint's whitelist
 
 ```
 USAGE
-  $ heroku pg:privatelink:access [DATABASE]
+  $ heroku data:privatelink:access [ADDON]
 
 OPTIONS
   -a, --app=app  (required) app to run command against
 
 EXAMPLE
-  $ heroku pg:privatelink:access postgresql-sushi-12345
+  $ heroku data:privatelink:access postgresql-sushi-12345
 ```
 
-_See code: [src/commands/pg/privatelink/access/index.ts](https://github.com/heroku/heroku-pg-privatelink-cli/blob/v0.8.0/src/commands/pg/privatelink/access/index.ts)_
+_See code: [src/commands/data/privatelink/access/index.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/access/index.ts)_
 
-## `heroku pg:privatelink:access:add [DATABASE]`
+## `heroku data:privatelink:access:add [ADDON]`
 
 add an account to your privatelink endpoint's whitelist
 
 ```
 USAGE
-  $ heroku pg:privatelink:access:add [DATABASE]
+  $ heroku data:privatelink:access:add [ADDON]
 
 OPTIONS
   -a, --app=app                        (required) app to run command against
   -i, --aws-account-id=aws-account-id  AWS account id to use
 
 EXAMPLES
-  $ heroku pg:privatelink:access:add postgresql-sushi-12345 --aws-account-id 123456789012:user/abc
-  $ heroku pg:privatelink:access:add postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --aws-account-id 
+  $ heroku data:privatelink:access:add postgresql-sushi-12345 --aws-account-id 123456789012:user/abc
+  $ heroku data:privatelink:access:add postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --aws-account-id 
   123456789012:user/xyz
 ```
 
-_See code: [src/commands/pg/privatelink/access/add.ts](https://github.com/heroku/heroku-pg-privatelink-cli/blob/v0.8.0/src/commands/pg/privatelink/access/add.ts)_
+_See code: [src/commands/data/privatelink/access/add.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/access/add.ts)_
 
-## `heroku pg:privatelink:access:remove [DATABASE]`
+## `heroku data:privatelink:access:remove [ADDON]`
 
 remove an account from your privatelink endpoint's whitelist
 
 ```
 USAGE
-  $ heroku pg:privatelink:access:remove [DATABASE]
+  $ heroku data:privatelink:access:remove [ADDON]
 
 OPTIONS
   -a, --app=app                        (required) app to run command against
   -i, --aws-account-id=aws-account-id  AWS account id to use
 
 EXAMPLES
-  $ heroku pg:privatelink:access:remove postgresql-sushi-12345 --aws-account-id 123456789012:user/xyz
-  $ heroku pg:privatelink:access:remove postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --aws-account-id 
+  $ heroku data:privatelink:access:remove postgresql-sushi-12345 --aws-account-id 123456789012:user/xyz
+  $ heroku data:privatelink:access:remove postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --aws-account-id 
   123456789012:user/xyz
 ```
 
-_See code: [src/commands/pg/privatelink/access/remove.ts](https://github.com/heroku/heroku-pg-privatelink-cli/blob/v0.8.0/src/commands/pg/privatelink/access/remove.ts)_
+_See code: [src/commands/data/privatelink/access/remove.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/access/remove.ts)_
 
-## `heroku pg:privatelink:create [DATABASE]`
+## `heroku data:privatelink:create [ADDON]`
 
 create a new privatelink endpoint for your database
 
 ```
 USAGE
-  $ heroku pg:privatelink:create [DATABASE]
+  $ heroku data:privatelink:create [ADDON]
 
 OPTIONS
   -a, --app=app                        (required) app to run command against
   -i, --aws-account-id=aws-account-id  AWS account id to use
 
 EXAMPLES
-  $ heroku pg:privatelink:create postgresql-sushi-12345 --aws-account-id 123456789012:user/abc
-  $ heroku pg:privatelink:create postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --account-id 
+  $ heroku data:privatelink:create postgresql-sushi-12345 --aws-account-id 123456789012:user/abc
+  $ heroku data:privatelink:create postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --account-id 
   123456789012:user/xyz
 ```
 
-_See code: [src/commands/pg/privatelink/create.ts](https://github.com/heroku/heroku-pg-privatelink-cli/blob/v0.8.0/src/commands/pg/privatelink/create.ts)_
+_See code: [src/commands/data/privatelink/create.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/create.ts)_
 
-## `heroku pg:privatelink:destroy [DATABASE]`
+## `heroku data:privatelink:destroy [ADDON]`
 
 destroy a privatelink endpoint for your database
 
 ```
 USAGE
-  $ heroku pg:privatelink:destroy [DATABASE]
+  $ heroku data:privatelink:destroy [ADDON]
 
 OPTIONS
   -a, --app=app  (required) app to run command against
 
 EXAMPLE
-  $ heroku pg:privatelink:destroy postgresql-sushi-12345
+  $ heroku data:privatelink:destroy postgresql-sushi-12345
 ```
 
-_See code: [src/commands/pg/privatelink/destroy.ts](https://github.com/heroku/heroku-pg-privatelink-cli/blob/v0.8.0/src/commands/pg/privatelink/destroy.ts)_
+_See code: [src/commands/data/privatelink/destroy.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/destroy.ts)_
 
-## `heroku pg:privatelink:wait [DATABASE]`
+## `heroku data:privatelink:wait [ADDON]`
 
 wait for your privatelink endpoint to be provisioned
 
 ```
 USAGE
-  $ heroku pg:privatelink:wait [DATABASE]
+  $ heroku data:privatelink:wait [ADDON]
 
 OPTIONS
   -a, --app=app  (required) app to run command against
 
 EXAMPLE
-  $ heroku pg:privatelink:wait postgresql-sushi-12345
+  $ heroku data:privatelink:wait postgresql-sushi-12345
 ```
 
-_See code: [src/commands/pg/privatelink/wait.ts](https://github.com/heroku/heroku-pg-privatelink-cli/blob/v0.8.0/src/commands/pg/privatelink/wait.ts)_
+_See code: [src/commands/data/privatelink/wait.ts](https://github.com/heroku/heroku-data-privatelink-cli/blob/v1.0.0/src/commands/data/privatelink/wait.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@heroku-cli/plugin-data-privatelink",
   "description": "Heroku Data via PrivateLink CLI",
-  "version": "1.0.0",
+  "version": "0.8.0",
   "author": "Heroku Data UX",
   "bugs": "https://github.com/heroku/heroku-data-privatelink-cli/issues",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@heroku-cli/plugin-pg-privatelink",
-  "description": "Heroku Postgres via PrivateLink CLI",
-  "version": "0.8.0",
+  "name": "@heroku-cli/plugin-data-privatelink",
+  "description": "Heroku Data via PrivateLink CLI",
+  "version": "1.0.0",
   "author": "Heroku Data UX",
-  "bugs": "https://github.com/heroku/heroku-pg-privatelink-cli/issues",
+  "bugs": "https://github.com/heroku/heroku-data-privatelink-cli/issues",
   "dependencies": {
     "@heroku-cli/color": "^1.1.14",
     "@heroku-cli/command": "^8.2.6",
@@ -43,7 +43,7 @@
     "/oclif.manifest.json",
     "/yarn.lock"
   ],
-  "homepage": "https://github.com/heroku/heroku-pg-privatelink-cli",
+  "homepage": "https://github.com/heroku/heroku-data-privatelink-cli",
   "keywords": [
     "oclif-plugin"
   ],
@@ -55,7 +55,7 @@
       "@oclif/plugin-help"
     ]
   },
-  "repository": "heroku/heroku-pg-privatelink-cli",
+  "repository": "heroku/heroku-data-privatelink-cli",
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "tslint -p test -t stylish",

--- a/src/commands/data/privatelink/access/add.ts
+++ b/src/commands/data/privatelink/access/add.ts
@@ -6,6 +6,7 @@ import fetcher from '../../../../lib/fetcher'
 
 export default class EndpointsAccessAdd extends BaseCommand {
   static description = 'add an account to your privatelink endpoint\'s whitelist'
+  static aliases = ['pg:privatelink:access:add', 'kafka:privatelink:access:add']
 
   static args = [
     {name: 'database'},
@@ -25,8 +26,8 @@ export default class EndpointsAccessAdd extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku pg:privatelink:access:add postgresql-sushi-12345 --aws-account-id 123456789012:user/abc',
-    '$ heroku pg:privatelink:access:add postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --aws-account-id 123456789012:user/xyz',
+    '$ heroku data:privatelink:access:add postgresql-sushi-12345 --aws-account-id 123456789012:user/abc',
+    '$ heroku data:privatelink:access:add postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --aws-account-id 123456789012:user/xyz',
   ]
 
   async run() {

--- a/src/commands/data/privatelink/access/index.ts
+++ b/src/commands/data/privatelink/access/index.ts
@@ -6,6 +6,7 @@ import fetcher from '../../../../lib/fetcher'
 
 export default class EndpointsAccessIndex extends BaseCommand {
   static description = 'list all accounts for your privatelink endpoint\'s whitelist'
+  static aliases = ['pg:privatelink:access', 'kafka:privatelink:access']
 
   static args = [
     {name: 'database'},
@@ -16,7 +17,7 @@ export default class EndpointsAccessIndex extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku pg:privatelink:access postgresql-sushi-12345',
+    '$ heroku data:privatelink:access postgresql-sushi-12345',
   ]
 
   async run() {

--- a/src/commands/data/privatelink/access/remove.ts
+++ b/src/commands/data/privatelink/access/remove.ts
@@ -6,6 +6,7 @@ import fetcher from '../../../../lib/fetcher'
 
 export default class EndpointsAccessRemove extends BaseCommand {
   static description = 'remove an account from your privatelink endpoint\'s whitelist'
+  static aliases = ['pg:privatelink:access:remove', 'kafka:privatelink:access:remove']
 
   static args = [
     {name: 'database'},
@@ -25,8 +26,8 @@ export default class EndpointsAccessRemove extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku pg:privatelink:access:remove postgresql-sushi-12345 --aws-account-id 123456789012:user/xyz',
-    '$ heroku pg:privatelink:access:remove postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --aws-account-id 123456789012:user/xyz',
+    '$ heroku data:privatelink:access:remove postgresql-sushi-12345 --aws-account-id 123456789012:user/xyz',
+    '$ heroku data:privatelink:access:remove postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --aws-account-id 123456789012:user/xyz',
   ]
 
   async run() {

--- a/src/commands/data/privatelink/create.ts
+++ b/src/commands/data/privatelink/create.ts
@@ -7,6 +7,7 @@ import fetcher from '../../../lib/fetcher'
 
 export default class EndpointsCreate extends BaseCommand {
   static description = 'create a new privatelink endpoint for your database'
+  static aliases = ['pg:privatelink:create', 'kafka:privatelink:create']
 
   static args = [
     {name: 'database'},
@@ -26,8 +27,8 @@ export default class EndpointsCreate extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku pg:privatelink:create postgresql-sushi-12345 --aws-account-id 123456789012:user/abc',
-    '$ heroku pg:privatelink:create postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --account-id 123456789012:user/xyz',
+    '$ heroku data:privatelink:create postgresql-sushi-12345 --aws-account-id 123456789012:user/abc',
+    '$ heroku data:privatelink:create postgresql-sushi-12345 --aws-account-id 123456789012:user/abc --account-id 123456789012:user/xyz',
   ]
 
   async run() {
@@ -51,6 +52,6 @@ export default class EndpointsCreate extends BaseCommand {
 
     this.log()
     this.log(`The privatelink endpoint is now being provisioned for ${color.cyan(database)}.`)
-    this.log(`Run ${color.cyan('heroku pg:privatelink:wait --app APP')} to check the creation process.`)
+    this.log(`Run ${color.cyan('heroku data:privatelink:wait --app APP')} to check the creation process.`)
   }
 }

--- a/src/commands/data/privatelink/destroy.ts
+++ b/src/commands/data/privatelink/destroy.ts
@@ -6,6 +6,7 @@ import fetcher from '../../../lib/fetcher'
 
 export default class EndpointsDestroy extends BaseCommand {
   static description = 'destroy a privatelink endpoint for your database'
+  static aliases = ['pg:privatelink:destroy', 'kafka:privatelink:destroy']
 
   static args = [
     {name: 'database'}
@@ -16,7 +17,7 @@ export default class EndpointsDestroy extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku pg:privatelink:destroy postgresql-sushi-12345',
+    '$ heroku data:privatelink:destroy postgresql-sushi-12345',
   ]
 
   async run() {

--- a/src/commands/data/privatelink/index.ts
+++ b/src/commands/data/privatelink/index.ts
@@ -7,6 +7,7 @@ import fetcher from '../../../lib/fetcher'
 
 export default class EndpointsIndex extends BaseCommand {
   static description = 'list all your privatelink endpoints!'
+  static aliases = ['pg:privatelink', 'kafka:privatelink']
 
   static args = [
     {name: 'database'}
@@ -17,7 +18,7 @@ export default class EndpointsIndex extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku pg:privatelink postgresql-sushi-12345',
+    '$ heroku data:privatelink postgresql-sushi-12345',
   ]
 
   async run() {
@@ -28,7 +29,7 @@ export default class EndpointsIndex extends BaseCommand {
     if (res.status === 'Provisioning') {
       this.log()
       this.log(`The privatelink endpoint is now being provisioned for ${color.cyan(database)}.`)
-      this.log(`Run ${color.cyan('heroku pg:privatelink:wait -a APP')} to check the creation process.`)
+      this.log(`Run ${color.cyan('heroku data:privatelink:wait -a APP')} to check the creation process.`)
     } else {
       cli.styledHeader(`privatelink endpoint status for ${color.cyan(database)}`)
       cli.styledObject({

--- a/src/commands/data/privatelink/wait.ts
+++ b/src/commands/data/privatelink/wait.ts
@@ -6,6 +6,7 @@ import fetcher from '../../../lib/fetcher'
 
 export default class EndpointsWait extends BaseCommand {
   static description = 'wait for your privatelink endpoint to be provisioned'
+  static aliases = ['pg:privatelink:wait', 'kafka:privatelink:wait']
 
   static args = [
     {name: 'database'}
@@ -16,7 +17,7 @@ export default class EndpointsWait extends BaseCommand {
   }
 
   static examples = [
-    '$ heroku pg:privatelink:wait postgresql-sushi-12345',
+    '$ heroku data:privatelink:wait postgresql-sushi-12345',
   ]
 
   async run() {

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -2,7 +2,7 @@ import {AddOn} from '@heroku-cli/schema'
 import {cli} from 'cli-ux'
 
 export default async function (heroku: any, addon_attachment: string, app: string) {
-  const db = addon_attachment || 'DATABASE_URL'
+  const db = addon_attachment
   const {body: res} = await heroku.post('/actions/addons/resolve', {
     body: {
       app,
@@ -14,15 +14,15 @@ export default async function (heroku: any, addon_attachment: string, app: strin
     cli.error(res.message)
   }
 
-  const filteredDb = res.find((addon: AddOn) => {
+  const filteredAddon = res.find((addon: AddOn) => {
     if (addon.addon_service) {
-      return addon.addon_service.name && addon.addon_service.name.startsWith('heroku-postgresql')
+      return addon.addon_service.name && addon.addon_service.name.startsWith('heroku-')
     }
   })
 
-  if (filteredDb) {
-    return filteredDb.name
+  if (filteredAddon) {
+    return filteredAddon.name
   } else {
-    cli.error('No databases found')
+    cli.error('No addons found')
   }
 }

--- a/test/commands/data/privatelink/access/add.test.ts
+++ b/test/commands/data/privatelink/access/add.test.ts
@@ -1,7 +1,7 @@
 import {addonsFetcherResponse} from '../../../../fixtures'
 import {expect, test} from '../../../../test'
 
-describe('pg:privatelink:access:add', () => {
+describe('data:privatelink:access:add', () => {
   test
     .nock('https://postgres-api.heroku.com', api => api
       .put('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:root']})
@@ -13,7 +13,7 @@ describe('pg:privatelink:access:add', () => {
     )
     .stdout()
     .stderr()
-    .command(['pg:privatelink:access:add', 'postgres-123', '--aws-account-id', '123456789012:root', '--app', 'myapp'])
+    .command(['data:privatelink:access:add', 'postgres-123', '--aws-account-id', '123456789012:root', '--app', 'myapp'])
     .it('adds an account to the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Adding account to the whitelist... done')
     })
@@ -29,7 +29,7 @@ describe('pg:privatelink:access:add', () => {
     )
     .stdout()
     .stderr()
-    .command(['pg:privatelink:access:add', 'postgres-123', '--aws-account-id', '123456789012:resource1', '--aws-account-id', '123456789012:resource2', '--app', 'myapp'])
+    .command(['data:privatelink:access:add', 'postgres-123', '--aws-account-id', '123456789012:resource1', '--aws-account-id', '123456789012:resource2', '--app', 'myapp'])
     .it('adds multiple accounts to the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Adding accounts to the whitelist... done')
     })

--- a/test/commands/data/privatelink/access/index.test.ts
+++ b/test/commands/data/privatelink/access/index.test.ts
@@ -1,7 +1,7 @@
 import {addonsFetcherResponse} from '../../../../fixtures'
 import {expect, test} from '../../../../test'
 
-describe('pg:privatelink:access', () => {
+describe('data:privatelink:access', () => {
   const privateLinkWhitelistResponse = {
     app: {name: 'myapp'},
     addon: {name: 'postgres-123'},
@@ -22,7 +22,7 @@ describe('pg:privatelink:access', () => {
     )
     .stdout()
     .stderr()
-    .command(['pg:privatelink:access', 'postgres-123', '--app', 'myapp'])
+    .command(['data:privatelink:access', 'postgres-123', '--app', 'myapp'])
     .it('shows all accounts in the whitelist', ctx => {
       expect(ctx.stdout).to.contain('ARN                         Status')
       expect(ctx.stdout).to.contain('arn:aws:iam::123456789:root Available')

--- a/test/commands/data/privatelink/access/remove.test.ts
+++ b/test/commands/data/privatelink/access/remove.test.ts
@@ -1,7 +1,7 @@
 import {addonsFetcherResponse} from '../../../../fixtures'
 import {expect, test} from '../../../../test'
 
-describe('pg:privatelink:access:remove', () => {
+describe('data:privatelink:access:remove', () => {
   test
     .nock('https://postgres-api.heroku.com', api => api
       .patch('/private-link/v0/databases/postgres-123/whitelisted_accounts', {whitelisted_accounts: ['123456789012:root']})
@@ -13,7 +13,7 @@ describe('pg:privatelink:access:remove', () => {
     )
     .stdout()
     .stderr()
-    .command(['pg:privatelink:access:remove', 'postgres-123', '--aws-account-id', '123456789012:root', '--app', 'myapp'])
+    .command(['data:privatelink:access:remove', 'postgres-123', '--aws-account-id', '123456789012:root', '--app', 'myapp'])
     .it('removes an account from the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Removing account from the whitelist... done')
     })
@@ -29,7 +29,7 @@ describe('pg:privatelink:access:remove', () => {
     )
     .stdout()
     .stderr()
-    .command(['pg:privatelink:access:remove', 'postgres-123', '--aws-account-id', '123456789012:resource1', '--aws-account-id', '123456789012:resource2', '--app', 'myapp'])
+    .command(['data:privatelink:access:remove', 'postgres-123', '--aws-account-id', '123456789012:resource1', '--aws-account-id', '123456789012:resource2', '--app', 'myapp'])
     .it('removes multiple accounts from the whitelist', ctx => {
       expect(ctx.stderr).to.contain('Removing accounts from the whitelist... done')
     })

--- a/test/commands/data/privatelink/create.test.ts
+++ b/test/commands/data/privatelink/create.test.ts
@@ -1,7 +1,7 @@
 import {addonsFetcherResponse} from '../../../fixtures'
 import {expect, test} from '../../../test'
 
-describe('pg:privatelink:create', () => {
+describe('data:privatelink:create', () => {
   test
     .nock('https://postgres-api.heroku.com', api => api
       .post('/private-link/v0/databases/postgres-123', {whitelisted_accounts: ['123456789012:root']})
@@ -13,7 +13,7 @@ describe('pg:privatelink:create', () => {
     )
     .stderr()
     .stdout()
-    .command(['pg:privatelink:create', 'postgres-123', '--aws-account-id', '123456789012:root', '--app', 'myapp'])
+    .command(['data:privatelink:create', 'postgres-123', '--aws-account-id', '123456789012:root', '--app', 'myapp'])
     .it('creates a privatelink endpoint with one account id', ctx => {
       expect(ctx.stderr).to.contain('Creating privatelink endpoint... done')
     })
@@ -29,7 +29,7 @@ describe('pg:privatelink:create', () => {
     )
     .stderr()
     .stdout()
-    .command(['pg:privatelink:create', 'postgres-123', '--aws-account-id', '123456789012:resource1', '--aws-account-id', '123456789012:resource2', '--app', 'myapp'])
+    .command(['data:privatelink:create', 'postgres-123', '--aws-account-id', '123456789012:resource1', '--aws-account-id', '123456789012:resource2', '--app', 'myapp'])
     .it('creates a privatelink endpoint with multiple account ids', ctx => {
       expect(ctx.stderr).to.contain('Creating privatelink endpoint... done')
     })

--- a/test/commands/data/privatelink/destroy.test.ts
+++ b/test/commands/data/privatelink/destroy.test.ts
@@ -1,7 +1,7 @@
 import {addonsFetcherResponse} from '../../../fixtures'
 import {expect, test} from '../../../test'
 
-describe('pg:privatelink:destroy', () => {
+describe('data:privatelink:destroy', () => {
   test
     .nock('https://postgres-api.heroku.com', api => api
       .delete('/private-link/v0/databases/postgres-123')
@@ -13,7 +13,7 @@ describe('pg:privatelink:destroy', () => {
     )
     .stderr()
     .stdout()
-    .command(['pg:privatelink:destroy', 'postgres-123', '--app', 'myapp'])
+    .command(['data:privatelink:destroy', 'postgres-123', '--app', 'myapp'])
     .it('destroys a privatelink endpoint', ctx => {
       expect(ctx.stderr).to.contain('Destroying privatelink endpoint... done')
     })

--- a/test/commands/data/privatelink/index.test.ts
+++ b/test/commands/data/privatelink/index.test.ts
@@ -15,7 +15,7 @@ describe('privatelink', () => {
     )
     .stdout()
     .stderr()
-    .command(['pg:privatelink', 'postgres-123', '--app', 'myapp'])
+    .command(['data:privatelink', 'postgres-123', '--app', 'myapp'])
     .it('shows the status of a privatelink endpoint, inc. whitelist and connections', ctx => {
       expect(ctx.stdout).to.contain('=== privatelink endpoint status for postgres-123')
       expect(ctx.stdout).to.contain('Service Name: com.amazonaws.vpce.testvpc')
@@ -41,9 +41,9 @@ describe('privatelink', () => {
     )
     .stdout()
     .stderr()
-    .command(['pg:privatelink', 'postgres-123', '--app', 'myapp'])
-    .it('tells the user to run heroku pg:privatelink:wait for a newly created endpoint', ctx => {
+    .command(['data:privatelink', 'postgres-123', '--app', 'myapp'])
+    .it('tells the user to run heroku data:privatelink:wait for a newly created endpoint', ctx => {
       expect(ctx.stdout).to.contain('The privatelink endpoint is now being provisioned for postgres-123.')
-      expect(ctx.stdout).to.contain('Run heroku pg:privatelink:wait -a APP to check the creation process.')
+      expect(ctx.stdout).to.contain('Run heroku data:privatelink:wait -a APP to check the creation process.')
     })
 })

--- a/test/commands/data/privatelink/wait.test.ts
+++ b/test/commands/data/privatelink/wait.test.ts
@@ -1,7 +1,7 @@
 import {addonsFetcherResponse} from '../../../fixtures'
 import {expect, test} from '../../../test'
 
-describe('pg:privatelink:wait', () => {
+describe('data:privatelink:wait', () => {
   const privateLinkListResponse = {
     app: {name: 'myapp'},
     addon: {name: 'postgres-123'},
@@ -22,7 +22,7 @@ describe('pg:privatelink:wait', () => {
     )
     .stdout()
     .stderr()
-    .command(['pg:privatelink:wait', 'postgres-123', '--app', 'myapp'])
+    .command(['data:privatelink:wait', 'postgres-123', '--app', 'myapp'])
     .it('waits for a privatelink endpoint to be provisioned', ctx => {
       expect(ctx.stderr).to.contain('Waiting for the privatelink endpoint to be provisioned... done')
     })


### PR DESCRIPTION
This commit expands the use of the privatelink cli to incorporate all
data addon types. This involves renaming a lot of `pg` specific commands
and references to now be prefixed with `data`. As such, the package name
has also been updating as well as the version to denote the major
change.

All previous `pg` prefixed commands are aliased to their new `data`
prefixed commands.